### PR TITLE
lambdas now take 2 params, the second being the local context

### DIFF
--- a/lib/mustache_context.dart
+++ b/lib/mustache_context.dart
@@ -55,7 +55,7 @@ class _MustacheContext extends MustacheToString implements MustacheContext {
   _getInThisOrParent(String key) {
     var result = _getContextForKey(key);
     //if the result is null, try the parent context
-    if (result == null && parent != null) {
+    if (result == null && !_hasActualValueSlot(key) && parent != null) {
       result = parent[key];
       if (result != null) {
         return _newMustachContextOrNull(result.ctx);        
@@ -101,7 +101,7 @@ class _MustacheContext extends MustacheToString implements MustacheContext {
     return new _MustacheContext(v, this);
   }
   
-  _getActualValue(String key) {
+  dynamic _getActualValue(String key) {
     try {
       return ctx[key];
     } catch (NoSuchMethodError) {
@@ -109,6 +109,14 @@ class _MustacheContext extends MustacheToString implements MustacheContext {
       //we do not want to use any reflector
       return (useMirrors && USE_MIRRORS) ? ctxReflector[key] : null;
     } 
+  }
+
+  bool _hasActualValueSlot(String key) {
+    if (ctx is Map) {
+      return (ctx as Map).containsKey(key);
+    } else {
+      return ctxReflector.hasSlot(key);
+    }
   }
   
   get ctxReflector {
@@ -190,6 +198,11 @@ class _ObjectReflector {
     
     return declaration.value;
   }
+
+  bool hasSlot(String key) {
+    var declaration = new _ObjectReflectorDeclaration(m, key);
+    return declaration != null;
+  }
 }
 
 class _ObjectReflectorDeclaration {
@@ -240,7 +253,7 @@ class _ObjectReflectorDeclaration {
     return null;
   }
   
-  //TODO check if we really need the declation is VariableMirror test
+  //TODO check if we really need the declaration is VariableMirror test
   bool get isVariableOrGetter => (declaration is VariableMirror) || (declaration is MethodMirror && declaration.isGetter);
   
   bool get isParameterlessMethod => declaration is MethodMirror && declaration.parameters.length == 0;

--- a/lib/mustache_context.dart
+++ b/lib/mustache_context.dart
@@ -45,7 +45,7 @@ class _MustacheContext extends MustacheToString implements MustacheContext {
   
   bool get isFalsey => ctx == null || ctx == false;
 
-  call([arg]) => isLambda ? ctx(arg) : ctx.toString();
+  call([arg]) => isLambda ? ctx(arg, this) : ctx.toString();
 
   operator [](String key) {
     if (ctx == null) return null;
@@ -208,10 +208,10 @@ class _ObjectReflectorDeclaration {
   
   _ObjectReflectorDeclaration._(this.mirror, this.declaration);
   
-  bool get isLambda => declaration.parameters.length == 1;
+  bool get isLambda => declaration.parameters.length == 2;
   
-  Function get lambda => (val) {
-    var im = mirror.invoke(declaration.simpleName, [val]);
+  Function get lambda => (val, ctx) {
+    var im = mirror.invoke(declaration.simpleName, [val, ctx]);
     if (im is InstanceMirror) {
       var r = im.reflectee;
       return r;

--- a/test/mustache_context_tests.dart
+++ b/test/mustache_context_tests.dart
@@ -78,11 +78,11 @@ void defineTests() {
         var f = ctx['transform'];
         
         expect(f.isLambda, true);
-        expect(f('123 456 777'), t.transform('123 456 777'));
+        expect(f('123 456 777'), t.transform('123 456 777', ctx));
       });
       
       test('MustacheFunction from anonymus function', () {
-        var map = {'transform': (String val) => "$val!"};
+        var map = {'transform': (String val, ctx) => "$val!"};
         var ctx = new MustacheContext(map);
         var f = ctx['transform'];
         
@@ -223,5 +223,5 @@ class _ContactInfo {
 }
 
 class _Transformer {
-  String transform(String val) => "<b>$val</b>";
+  String transform(String val, ctx) => "<b>$val</b>";
 }

--- a/test/mustache_issues.dart
+++ b/test/mustache_issues.dart
@@ -17,6 +17,18 @@ class B extends A {
   B(String name) : super(name);
 }
 
+class Parent {
+  String foo;
+}
+
+class Child extends Parent {
+  List<OtherChild> children = [];
+}
+
+class OtherChild extends Parent {
+
+}
+
 void main() {
   defineTests();
 }
@@ -125,6 +137,21 @@ defineTests() {
 
       var output = render(template, context);
       var expected = "!!!one!!!|\n!!!two!!!|\n";
+
+      expect(output, expected);
+    });
+
+    test('#41 do not look into parent context if current context has field but its value is null', () {
+      var c = new Child()
+        ..foo = 'child'
+        ..children = [new OtherChild()..foo='otherchild', new OtherChild()..foo=null];
+
+      var template = '''
+{{foo}}
+{{#children}}{{foo}}!{{/children}}''';
+
+      var output = render(template, c);
+      var expected = "child\notherchild!!";
 
       expect(output, expected);
     });

--- a/test/mustache_issues.dart
+++ b/test/mustache_issues.dart
@@ -7,12 +7,14 @@ import 'package:mustache4dart/mustache4dart.dart';
 import 'package:mustache4dart/mustache_context.dart';
 
 class A {
+  String name;
+  A(this.name);
   String getBar () => 'bar';
   String get foo => 'foo';
 }
 
 class B extends A {
-
+  B(String name) : super(name);
 }
 
 void main() {
@@ -97,9 +99,34 @@ defineTests() {
     });
 
     test('#33', () {
-      var b = new B();
+      var b = new B('b');
       expect(render('{{b.foo}}', {'b': b}), 'foo');
       expect(render('{{b.bar}}', {'b': b}), 'bar');
+    });
+
+    test('#39 handle sub-contexts and lambdas', () {
+      var map = {
+        'things': [
+          new A('one'),
+          new A('two')
+        ]
+      };
+
+      var template = '''
+{{#map.things}}
+{{#lambda}}{{name}}{{/lambda}}|
+{{/map.things}}
+''';
+
+      var context = {
+        'map': map,
+        'lambda': (String s, ctx) => "!!!" + render(s, ctx) + "!!!"
+      };
+
+      var output = render(template, context);
+      var expected = "!!!one!!!|\n!!!two!!!|\n";
+
+      expect(output, expected);
     });
   });
 }

--- a/test/mustache_specs.dart
+++ b/test/mustache_specs.dart
@@ -76,21 +76,21 @@ bool shouldRun(String filename) {
 class _DummyCallableWithState {
   var _callCounter = 0;
   
-  call (arg) => "${++_callCounter}";
+  call (arg, ctx) => "${++_callCounter}";
   
   reset () => _callCounter = 0; 
 }
 
 var lambdas = {
-               'Interpolation' : (t) => 'world',
-               'Interpolation - Expansion': (t) => '{{planet}}',
-               'Interpolation - Alternate Delimiters': (t) => "|planet| => {{planet}}",
+               'Interpolation' : (t, ctx) => 'world',
+               'Interpolation - Expansion': (t, ctx) => '{{planet}}',
+               'Interpolation - Alternate Delimiters': (t, ctx) => "|planet| => {{planet}}",
                'Interpolation - Multiple Calls': new _DummyCallableWithState(), //function() { return (g=(function(){return this})()).calls=(g.calls||0)+1 }
-               'Escaping': (t) => '>',
-               'Section': (txt) => txt == "{{x}}" ? "yes" : "no",
-               'Section - Expansion': (txt) => "$txt{{planet}}$txt",
-               'Section - Alternate Delimiters': (txt) => "$txt{{planet}} => |planet|$txt",
-               'Section - Multiple Calls': (t) => "__${t}__",
-               'Inverted Section': (txt) => false
+               'Escaping': (t, ctx) => '>',
+               'Section': (txt, ctx) => txt == "{{x}}" ? "yes" : "no",
+               'Section - Expansion': (txt, ctx) => "$txt{{planet}}$txt",
+               'Section - Alternate Delimiters': (txt, ctx) => "$txt{{planet}} => |planet|$txt",
+               'Section - Multiple Calls': (t, ctx) => "__${t}__",
+               'Inverted Section': (txt, ctx) => false
                
 };


### PR DESCRIPTION
Addresses https://github.com/valotas/mustache4dart/issues/39

All tests are passing on my machine.

NOTE: this is a breaking change. Lambdas now expect two params: the string and the context. Consider bumping version to 1.1.

If you want to support one or two parameter lambdas, you can do it.

```
typedef OneParamLambda(String s);
typedef TwoParamLambda(String s, dynamic ctx);
```

And then in your lambda calling logic:

```
if (lambda is OneParamLambda) {
  return lambda(string);
} else if (lambda is TwoParamLambda) {
  return lambda(string, ctx);
}
```

I did not do this, as I'm not sure if you care.


BTW is context always a `MustacheContext` ? I wasn't sure, so I left it dynamic.