### PR TITLE
Avoid trapping exceptions by using reflection

### DIFF
--- a/lib/mustache_context.dart
+++ b/lib/mustache_context.dart
@@ -124,22 +124,31 @@ class _MustacheContext extends MustacheToString implements MustacheContext {
   }
 
   dynamic _getActualValue(String key) {
-    if (reflect(ctx).type.instanceMembers.containsKey(new Symbol("[]"))) {
-      MethodMirror m = reflect(ctx).type.instanceMembers[new Symbol("[]")];
-      TypeMirror reflectedString = reflectType(String);
-      if (reflectedString.isAssignableTo(m.parameters[0].type)) {
-        try {
-          return ctx[key];
-        } catch (NoSuchMethodError) {
-          // This should never happen unless we were trapping a lower level
-          // NoSuchMethodError before.  Continue to do so to be bug-for-bug
-          // compatible.
+    //Try to make dart2js understand that when we define USE_MIRRORS = false
+    //we do not want to use any reflector as that inflates the generated
+    //javascript.
+    if (useMirrors && USE_MIRRORS) {
+      if (reflect(ctx).type.instanceMembers.containsKey(new Symbol("[]"))) {
+        MethodMirror m = reflect(ctx).type.instanceMembers[new Symbol("[]")];
+        TypeMirror reflectedString = reflectType(String);
+        if (reflectedString.isAssignableTo(m.parameters[0].type)) {
+          try {
+            return ctx[key];
+          } catch (NoSuchMethodError) {
+            //This should never happen unless we were trapping a lower level
+            //NoSuchMethodError before.  Continue to do so to be bug-for-bug
+            //compatible.
+          }
         }
       }
+      return ctxReflector[key];
+    } else {
+      try {
+        return ctx[key];
+      } catch (NoSuchMethodError) {
+        return null;
+      }
     }
-    //Try to make dart2js understand that when we define USE_MIRRORS = false
-    //we do not want to use any reflector
-    return (useMirrors && USE_MIRRORS) ? ctxReflector[key] : null;
   }
 
   bool _hasActualValueSlot(String key) {

--- a/lib/src/mustache.dart
+++ b/lib/src/mustache.dart
@@ -8,10 +8,7 @@ render(String template, Object context,
     bool errorOnMissingProperty: false,
     bool assumeNullNonExistingProperty: true}) {
   return compile(template,
-      partial: partial,
-      delimiter: delimiter,
-      ident:
-          ident)(context,
+          partial: partial, delimiter: delimiter, ident: ident)(context,
       out: out,
       errorOnMissingProperty: errorOnMissingProperty,
       assumeNullNonExistingProperty: assumeNullNonExistingProperty);


### PR DESCRIPTION
Currently, dartdoc makes extensive use of the exception trapping and reflection inside mustache4dart.  But trapping exceptions is expensive and profiling suggests a great deal of time is spent in here.  This should remove the hotspot for clients like dartdoc without altering mustache4dart's behavior.