### PR TITLE
Fix inference problem with _MustacheContext

### DIFF
--- a/lib/mustache_context.dart
+++ b/lib/mustache_context.dart
@@ -105,7 +105,7 @@ class _MustacheContext implements MustacheContext {
     }
     if (key.contains(DOT)) {
       final Iterator<String> i = key.split(DOT).iterator;
-      var val = this;
+      MustacheContext val = this;
       while (i.moveNext()) {
         val = val._getMustacheContext(i.current);
         if (val == null) {


### PR DESCRIPTION
With --preview-dart-2 val is inferred to be _MustacheContext, which results in a type error if something that is a valid MustacheContext but not a _MustacheContext is assigned to val at line 110:

```
dart2-dartdoc_test.dart:   type '_IterableMustacheContextDecorator' is not a subtype of type '_MustacheContext' where
dart2-dartdoc_test.dart:     _IterableMustacheContextDecorator is from package:mustache4dart/mustache_context.dart
dart2-dartdoc_test.dart:     _MustacheContext is from package:mustache4dart/mustache_context.dart
dart2-dartdoc_test.dart:     _MustacheContext is from package:mustache4dart/mustache_context.dart
dart2-dartdoc_test.dart:
```